### PR TITLE
changed class modifiers from public to open

### DIFF
--- a/Sources/LoadableFromXibView.swift
+++ b/Sources/LoadableFromXibView.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 
-public class LoadableFromXibView: UIView {
+open class LoadableFromXibView: UIView {
   
   @IBOutlet public weak var view: UIView!
   

--- a/Sources/ScrollableDatepicker.swift
+++ b/Sources/ScrollableDatepicker.swift
@@ -11,7 +11,7 @@ public protocol ScrollableDatepickerDelegate: class {
 }
 
 
-public class ScrollableDatepicker: LoadableFromXibView {
+open class ScrollableDatepicker: LoadableFromXibView {
   
   @IBOutlet public weak var collectionView: UICollectionView! {
     didSet {

--- a/Sources/ScrollableDatepickerDayCell.swift
+++ b/Sources/ScrollableDatepickerDayCell.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 
-public class ScrollableDatepickerDayCell: UICollectionViewCell {
+open class ScrollableDatepickerDayCell: UICollectionViewCell {
   
   public let selectorColor = UIColor(red: 242.0/255.0, green: 93.0/255.0, blue: 28.0/255.0, alpha: 1.0)
   


### PR DESCRIPTION
By changing it to open, it will allow us to extend the Cell-Class. By doing so, we can register our own XIB's for the Cell for custom cell design.